### PR TITLE
cmd/sprig: fix environment variable parsing

### DIFF
--- a/cmd/sprig/sprig.go
+++ b/cmd/sprig/sprig.go
@@ -94,9 +94,10 @@ func (i *sprigCommand) vals() (map[string]interface{}, error) {
 	// Environment set stuff
 	if i.envValues {
 		envMap := map[string]interface{}{}
-		envKeys := os.Environ()
-		for _, key := range envKeys {
-			envMap[key] = os.Getenv(key)
+		envVars := os.Environ()
+		for _, envVar := range envVars {
+			splitVar := strings.SplitN(envVar, "=", 2)
+			envMap[splitVar[0]] = splitVar[1]
 		}
 		base = mergeValues(base, envMap)
 	}

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -25,3 +25,16 @@ key: value
 	assert.Nil(t, err)
 	assert.Equal(t, string(out), "foo is bar and keyx2 is valuevalue")
 }
+
+func TestEnvUsage(t *testing.T) {
+	inputFile := "The value of environment variable foo was {{ .foo }}"
+	f, err := ioutil.TempFile("", "sprig_testin")
+	f.WriteString(inputFile)
+	env := []string{"foo=read from the environment"}
+
+	cmd := exec.Command("../bin/sprig", "--env", f.Name())
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	assert.Nil(t, err)
+	assert.Equal(t, string(out), "The value of environment variable foo was read from the environment")
+}


### PR DESCRIPTION
`os.Environ()` returns a slice of "key=value" strings representing the
environment. This commit fixes the behavior of sprigCommand.vals() to
parse environment variables correctly. It also renames `envKeys` to
`envVars` as it is slightly more descriptive of the contents and adds a
test to confirm that environment variables are read correctly.